### PR TITLE
Clean up apt lists in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     apt-transport-https \
     software-properties-common \
-    gnupg2
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add Sury PHP repository (alternative to PPA for Debian)
 RUN curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \


### PR DESCRIPTION
This change adds a cleanup command (`rm -rf /var/lib/apt/lists/*`) after `apt-get update` in the `Dockerfile`. This is a standard optimization to reduce the size of the Docker image layer by removing the apt package lists after they are no longer needed.

---
*PR created automatically by Jules for task [11733597170371088902](https://jules.google.com/task/11733597170371088902) started by @uluumbch*